### PR TITLE
Manual slotting using ManualSlotController

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,10 @@
 
 <body style="margin: 0; padding: 0;">
 <ilw-breadcrumbs>
-    <ol>
-        <li><a href="/">Home</a></li>
-        <li><a href="/academics">Academics</a></li>
-        <li><a href="/academics/undergraduate">Undergraduate programs</a></li>
-        <li><span>Degree programs</span></li>
-    </ol>
+    <a href="/">Home</a>
+    <a href="/academics">Academics</a>
+    <a href="/academics/undergraduate">Undergraduate programs</a>
+    <span>Degree programs</span>
 </ilw-breadcrumbs>
 </body>
 

--- a/samples/index.html
+++ b/samples/index.html
@@ -12,12 +12,10 @@
 
 <body style="margin: 0; padding: 0;">
 <ilw-breadcrumbs>
-    <ol>
-        <li><a href="/">Home</a></li>
-        <li><a href="/academics">Academics</a></li>
-        <li><a href="/academics/undergraduate">Undergraduate programs</a></li>
-        <li><span>Degree programs</span></li>
-    </ol>
+    <a href="/">Home</a>
+    <a href="/academics">Academics</a>
+    <a href="/academics/undergraduate">Undergraduate programs</a>
+    <span>Degree programs</span>
 </ilw-breadcrumbs>
 </body>
 

--- a/src/ManualSlotController.js
+++ b/src/ManualSlotController.js
@@ -1,0 +1,72 @@
+/**
+ * A simple Lit reactive controller to apply manual slotting to a component.
+ *
+ * Using manual slotting gives us the ability to surround the child nodes with additional
+ * elements without resorting to manipulating the page's DOM. This is important for
+ * elements with strict parent-child relationships, like `ul` and `li`, since otherwise
+ * they would require the component's user to add those elements.
+ *
+ * When using this:
+ * - Make sure your component has `slotAssignment: "manual"` in its shadowRootOptions.
+ * - Add the `_observer = new ManualSlotController(this)` property to your component's class.
+ * - In your component's render, map over children to create the slots. Something like:
+ *
+ * ```
+ * ${map(Array.from(this.children), () => html`<li><slot></slot></li>`)}
+ * ```
+ */
+export class ManualSlotController {
+    /**
+     * @type import("lit").LitElement
+     * @private
+     */
+    _host;
+
+    /**
+     * @type MutationObserver
+     * @private
+     */
+    _observer;
+
+    /**
+     * @param {import("lit").LitElement} host
+     */
+    constructor(host) {
+        this._host = host;
+        this._observer = new MutationObserver((list) => {
+            this._host.requestUpdate();
+        });
+        // This binds the controller to the element's lifecycle
+        host.addController(this);
+    }
+
+    /**
+     * Find the child nodes and slots, and assign the children to each slot.
+     *
+     * The render of the host component is expected to create the slots, but this
+     * function will take care of assigning the elements to them.
+     * @private
+     */
+    _refreshInternal() {
+        let items = Array.from(this._host.children);
+        let slots = Array.from(this._host.shadowRoot.querySelectorAll('slot'));
+        for (let slot of slots) {
+            if (items.length > 0) {
+                slot.assign(items.shift());
+            }
+        }
+    }
+
+    hostUpdated() {
+        // Called by Lit after the host component's render.
+        this._refreshInternal();
+    }
+
+    hostConnected() {
+        this._observer.observe(this._host, {childList: true});
+    }
+
+    disconnect() {
+        this._observer.disconnect();
+    }
+}

--- a/src/ilw-breadcrumbs.js
+++ b/src/ilw-breadcrumbs.js
@@ -1,8 +1,14 @@
 import { LitElement, html } from 'lit';
+import { map } from 'lit/directives/map.js';
 import styles from './ilw-breadcrumbs.styles.js';
 import './ilw-breadcrumbs.css';
+import { ManualSlotController } from "./ManualSlotController.js";
 
 class Breadcrumbs extends LitElement {
+
+    static shadowRootOptions = {...LitElement.shadowRootOptions, slotAssignment: "manual"};
+
+    _observer = new ManualSlotController(this);
 
     static get properties() {
         return {
@@ -21,9 +27,11 @@ class Breadcrumbs extends LitElement {
 
     render() {
         return html`
-      <nav aria-label=${this.label} class="breadcrumb">
-        <slot></slot>
-      </nav>
+        <nav aria-label=${this.label} class="breadcrumb">
+            <ol>
+                ${map(Array.from(this.children), () => html`<li><slot></slot></li>`)}
+            </ol>
+        </nav>
     `;
     }
 }


### PR DESCRIPTION
This utilizes the same technique as https://github.com/web-illinois/ilw-grid - the Controller class makes it easier to use the manual slotting, and it takes care of updating it as well.

The CSS will need to be updated and moved from `ilw-breadcrumbs.css` to `ilw-breadcrumbs.styles.js`, since the elements it's styling moved into the component.